### PR TITLE
fix: Signing type from array to object

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,7 +54,7 @@ export default defineConfig({
 	// Github Actions runners have 2 logical CPU cores
 	// Defaults to half of the logical CPU cores available
 	// Docs: https://playwright.dev/docs/api/class-testconfig#test-config-workers
-	workers: process.env.CI ? 1 : undefined,
+	workers: 1,
 
 	// Limit the numbers of failures to set a fail-fast strategy on CI
 	// Docs: https://playwright.dev/docs/api/class-testconfig#test-config-max-failures

--- a/src/controllers/did.ts
+++ b/src/controllers/did.ts
@@ -33,6 +33,12 @@ export class DidController {
 	];
 
 	public static updateValidator = [
+		check('did')
+			.optional()
+			.isString()
+			.withMessage(Messages.InvalidDid)
+			.contains('did:cheqd:')
+			.withMessage(Messages.InvalidDid),
 		check('didDocument')
 			.optional()
 			.isArray()
@@ -44,12 +50,6 @@ export class DidController {
 		check('jobId')
 			.custom((value, { req }) => value || (req.body.did && req.body.didDocument))
 			.withMessage(Messages.Invalid),
-		check('did')
-			.optional()
-			.isString()
-			.withMessage(Messages.InvalidDid)
-			.contains('did:cheqd:')
-			.withMessage(Messages.InvalidDid),
 		check('didDocumentOperation')
 			.optional()
 			.isArray()
@@ -105,7 +105,6 @@ export class DidController {
 
 		if (secret.signingResponse) {
 			signInputs = convertToSignInfo(secret.signingResponse);
-			console.log(signInputs);
 		} else {
 			LocalStore.instance.setItem(jobId, { didDocument, state: IState.Action, versionId });
 			return response

--- a/src/controllers/did.ts
+++ b/src/controllers/did.ts
@@ -29,9 +29,7 @@ export class DidController {
 
 	public static commonValidator = [
 		check('options.versionId').optional().isString().withMessage(Messages.InvalidOptions),
-		check('secret.signingResponse').optional().isArray().withMessage(Messages.InvalidSecret),
-		check('secret.signingResponse.*.signature').isString().withMessage(Messages.InvalidSecret),
-		check('secret.signingResponse.*.kid').isString().withMessage(Messages.InvalidSecret),
+		check('secret.signingResponse').optional().isObject().withMessage(Messages.InvalidSecret),
 	];
 
 	public static updateValidator = [
@@ -107,6 +105,7 @@ export class DidController {
 
 		if (secret.signingResponse) {
 			signInputs = convertToSignInfo(secret.signingResponse);
+			console.log(signInputs);
 		} else {
 			LocalStore.instance.setItem(jobId, { didDocument, state: IState.Action, versionId });
 			return response

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -6,13 +6,17 @@ import { base64ToBytes } from 'did-jwt';
 
 import { ISignInfo } from '../types/types.js';
 
-export function convertToSignInfo(payload: ISignInfo[]): SignInfo[] {
-	return payload.map((value) => {
-		return {
-			verificationMethodId: value.kid,
-			signature: base64ToBytes(value.signature),
-		};
-	});
+export function convertToSignInfo(payload: Record<string, ISignInfo>): SignInfo[] {
+	const signInfo = [];
+	for (var key in payload) {
+		if (payload[key])
+			signInfo.push({
+				verificationMethodId: payload[key].kid,
+				signature: base64ToBytes(payload[key].signature),
+			});
+	}
+
+	return signInfo;
 }
 
 export function validateSpecCompliantPayload(didDocument: DIDDocument): SpecValidationResult {

--- a/src/helpers/response.ts
+++ b/src/helpers/response.ts
@@ -63,7 +63,7 @@ export class Responses {
 				description: Messages.GetSignature,
 				signingRequest,
 				secret: {
-					signingResponse: [Messages.SigingResponse],
+					signingResponse: Messages.SigingResponse,
 				},
 			},
 		};
@@ -95,7 +95,7 @@ export class Responses {
 				description: Messages.GetSignature,
 				signingRequest,
 				secret: {
-					signingResponse: [Messages.SigingResponse],
+					signingResponse: Messages.SigingResponse,
 				},
 			},
 		};
@@ -129,7 +129,7 @@ export class Responses {
 				description: Messages.GetSignature,
 				signingRequest,
 				secret: {
-					signingResponse: [Messages.SigingResponse],
+					signingResponse: Messages.SigingResponse,
 				},
 			},
 		};
@@ -163,7 +163,7 @@ export class Responses {
 				description: Messages.GetSignature,
 				signingRequest,
 				secret: {
-					signingResponse: [Messages.SigingResponse],
+					signingResponse: Messages.SigingResponse,
 				},
 			},
 		};

--- a/src/helpers/response.ts
+++ b/src/helpers/response.ts
@@ -70,8 +70,9 @@ export class Responses {
 	}
 
 	static GetDeactivateDidSignatureResponse(jobId: string, payload: DIDDocument, versionId: string) {
-		const signingRequest = payload.verificationMethod!.map((method) => {
-			return {
+		const signingRequest: Record<string, any> = {};
+		payload.verificationMethod!.map((method, index) => {
+			signingRequest[`signingRequest${index}`] = {
 				kid: method.id,
 				type: method.type,
 				alg: 'EdDSA',
@@ -105,8 +106,10 @@ export class Responses {
 		verificationMethod: VerificationMethod[],
 		resource: Partial<MsgCreateResourcePayload>
 	) {
-		const signingRequest = verificationMethod.map((method) => {
-			return {
+		const signingRequest: Record<string, any> = {};
+
+		verificationMethod.forEach((method, index) => {
+			signingRequest[`signingRequest${index}`] = {
 				kid: method.id,
 				type: method.type,
 				alg: 'EdDSA',
@@ -137,8 +140,10 @@ export class Responses {
 		did: string,
 		resource: Partial<MsgCreateResourcePayload>
 	) {
-		const signingRequest = verificationMethod.map((method) => {
-			return {
+		const signingRequest: Record<string, any> = {};
+
+		verificationMethod.forEach((method, index) => {
+			signingRequest[`signingRequest${index}`] = {
 				kid: method.id,
 				type: method.type,
 				alg: 'EdDSA',

--- a/src/helpers/response.ts
+++ b/src/helpers/response.ts
@@ -15,7 +15,7 @@ export class Responses {
 			jobId,
 			didState: {
 				did: didDocument.id,
-				state: 'finished',
+				state: IState.Finished,
 				secret,
 				didDocument,
 			},
@@ -25,8 +25,10 @@ export class Responses {
 	static async GetDIDActionSignatureResponse(jobId: string, didPayload: DIDDocument, versionId: string) {
 		const { protobufVerificationMethod, protobufService } =
 			await DIDModule.validateSpecCompliantPayload(didPayload);
-		const signingRequest = didPayload.verificationMethod!.map((method) => {
-			return {
+		const signingRequest: Record<string, any> = {};
+
+		didPayload.verificationMethod!.forEach((method, index) => {
+			signingRequest[`signingRequest${index}`] = {
 				kid: method.id,
 				type: method.type,
 				alg: 'EdDSA',

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -15,7 +15,7 @@ export enum Messages {
 	InvalidContent = 'Resource Content is invalid',
 	InvalidUpdateResource = 'Update resource name or type does not match existing resource',
 	TestnetFaucet = 'sketch mountain erode window enact net enrich smoke claim kangaroo another visual write meat latin bacon pulp similar forum guilt father state erase bright',
-	SigingResponse = 'e.g. { kid: did:cheqd:testnet:qsqdcansoica#key-1, signature: aca1s12q14213casdvaadcfas }',
+	SigingResponse = 'e.g. { signingRequest0: { kid: did:cheqd:testnet:qsqdcansoica#key-1, signature: aca1s12q14213casdvaadcfas }, signingRequest1: ... }',
 	InvalidOptions = 'The provided options are invalid',
 	InvalidSecret = 'The provided secret is invalid',
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -89,7 +89,7 @@ export interface IDecryptionInfo {
 
 export interface ISecret {
 	verificationMethod?: VerificationMethod[];
-	signingResponse?: ISignInfo[];
+	signingResponse?: Record<string, ISignInfo>;
 	decryptionResponse?: IDecryptionInfo[];
 }
 

--- a/tests/did/01-did-create.spec.ts
+++ b/tests/did/01-did-create.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { sign } from '@stablelib/ed25519';
-import { toString, fromString } from 'uint8arrays';
+import { toString } from 'uint8arrays';
 import { getDidDocument, privKeyBytes, pubKeyHex, setDidDocument } from 'fixtures';
 
 let didState;
@@ -49,17 +49,19 @@ test('did-create. Initiate DID Create procedure', async ({ request }) => {
 
 test('did-create. Send the final request for DID creating', async ({ request }) => {
 	const didPayload = getDidDocument();
-	const serializedPayload = didState.signingRequest[0].serializedPayload;
+	const signingRequest = didState.signingRequest['signingRequest0'];
+
+	const serializedPayload = signingRequest.serializedPayload;
 	const serializedBytes = Buffer.from(serializedPayload, 'base64');
 	const signature = sign(privKeyBytes, serializedBytes);
 
 	const secret = {
-		signingResponse: [
-			{
-				kid: didState.signingRequest[0].kid,
+		signingResponse: {
+			signingRequest0: {
+				kid: signingRequest.kid,
 				signature: toString(signature, 'base64'),
 			},
-		],
+		},
 	};
 
 	const didCreate = await request.post(`/1.0/create/`, {

--- a/tests/did/02-did-update.spec.ts
+++ b/tests/did/02-did-update.spec.ts
@@ -46,17 +46,18 @@ test('did-update. Initiate DID Update procedure', async ({ request }) => {
 });
 
 test('did-update. Send the final request for DID updating', async ({ request }) => {
-	const serializedPayload = didState.signingRequest[0].serializedPayload;
+	const signingRequest = didState.signingRequest['signingRequest0'];
+	const serializedPayload = signingRequest.serializedPayload;
 	const serializedBytes = Buffer.from(serializedPayload, 'base64');
 	const signature = sign(privKeyBytes, serializedBytes);
 
 	const secret = {
-		signingResponse: [
-			{
-				kid: didState.signingRequest[0].kid,
+		signingResponse: {
+			signingRequest0: {
+				kid: signingRequest.kid,
 				signature: toString(signature, 'base64'),
 			},
-		],
+		},
 	};
 
 	const didUpdate = await request.post(`/1.0/update`, {

--- a/tests/did/03-did-deactivate.spec.ts
+++ b/tests/did/03-did-deactivate.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { sign } from '@stablelib/ed25519';
-import { toString, fromString } from 'uint8arrays';
+import { toString } from 'uint8arrays';
 import { getDidDocument, privKeyBytes } from 'fixtures';
 
 let didState;
@@ -34,17 +34,18 @@ test('did-deactivate. Initiate DID Deactivate procedure', async ({ request }) =>
 
 test('did-deactivate. Send the final request for DID deactivating', async ({ request }) => {
 	const didPayload = getDidDocument();
-	const serializedPayload = didState.signingRequest[0].serializedPayload;
+	const signingRequest = didState.signingRequest['signingRequest0'];
+	const serializedPayload = signingRequest.serializedPayload;
 	const serializedBytes = Buffer.from(serializedPayload, 'base64');
 	const signature = sign(privKeyBytes, serializedBytes);
 
 	const secret = {
-		signingResponse: [
-			{
-				kid: didState.signingRequest[0].kid,
+		signingResponse: {
+			signingRequest0: {
+				kid: signingRequest.kid,
 				signature: toString(signature, 'base64'),
 			},
-		],
+		},
 	};
 
 	const didDeactivate = await request.post(`/1.0/deactivate`, {

--- a/tests/did/04-negative.spec.ts
+++ b/tests/did/04-negative.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import { toString, fromString } from 'uint8arrays';
 import { getDidDocument } from 'fixtures';
 
 let indyDid = 'did:indy:sovrin:WRfXPg8dantKVubE3HX8pw';

--- a/tests/resource/01-resource-create.spec.ts
+++ b/tests/resource/01-resource-create.spec.ts
@@ -51,14 +51,15 @@ test('resource-create. Initiate DID Create procedure', async ({ request }) => {
 
 test('resource-create. Send the final request for DID creation', async ({ request }) => {
 	const didPayload = getDidDocument();
-	const serializedPayload = didState.signingRequest[0].serializedPayload;
+	const signingRequest = resourceState.signingRequest['signingRequest0'];
+	const serializedPayload = signingRequest.serializedPayload;
 	const serializedBytes = Buffer.from(serializedPayload, 'base64');
 	const signature = sign(privKeyBytes, serializedBytes);
 
 	const secret = {
 		signingResponse: [
 			{
-				kid: didState.signingRequest[0].kid,
+				kid: signingRequest.kid,
 				signature: toString(signature, 'base64'),
 			},
 		],
@@ -101,17 +102,18 @@ test('resource-create. Initiate Resource creation procedure', async ({ request }
 
 test('resource-create. Send the final request for Resource creation', async ({ request }) => {
 	const didPayload = getDidDocument();
-	const serializedPayload = resourceState.signingRequest[0].serializedPayload;
+	const signingRequest = resourceState.signingRequest['signingRequest0'];
+	const serializedPayload = signingRequest.serializedPayload;
 	const serializedBytes = Buffer.from(serializedPayload, 'base64');
 	const signature = sign(privKeyBytes, serializedBytes);
 
 	const secret = {
-		signingResponse: [
-			{
-				kid: resourceState.signingRequest[0].kid,
+		signingResponse: {
+			signingRequest0: {
+				kid: signingRequest.kid,
 				signature: toString(signature, 'base64'),
 			},
-		],
+		},
 	};
 
 	const resourceCreate = await request.post(`/1.0/${didPayload.id}/create-resource`, {

--- a/tests/resource/01-resource-create.spec.ts
+++ b/tests/resource/01-resource-create.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { sign } from '@stablelib/ed25519';
-import { toString, fromString } from 'uint8arrays';
+import { toString } from 'uint8arrays';
 import { getDidDocument, privKeyBytes, pubKeyHex, setDidDocument } from 'fixtures';
 
 let didState;
@@ -51,18 +51,18 @@ test('resource-create. Initiate DID Create procedure', async ({ request }) => {
 
 test('resource-create. Send the final request for DID creation', async ({ request }) => {
 	const didPayload = getDidDocument();
-	const signingRequest = resourceState.signingRequest['signingRequest0'];
+	const signingRequest = didState.signingRequest['signingRequest0'];
 	const serializedPayload = signingRequest.serializedPayload;
 	const serializedBytes = Buffer.from(serializedPayload, 'base64');
 	const signature = sign(privKeyBytes, serializedBytes);
 
 	const secret = {
-		signingResponse: [
-			{
+		signingResponse: {
+			signingRequest0: {
 				kid: signingRequest.kid,
 				signature: toString(signature, 'base64'),
 			},
-		],
+		},
 	};
 
 	const didCreate = await request.post(`/1.0/create/`, {

--- a/tests/resource/02-createResource.spec.ts
+++ b/tests/resource/02-createResource.spec.ts
@@ -35,17 +35,18 @@ test('resource-create. Initiate Resource creation procedure', async ({ request }
 
 test('resource-create. Send the final request for Resource creation', async ({ request }) => {
 	const didPayload = getDidDocument();
-	const serializedPayload = didUrlState.signingRequest[0].serializedPayload;
+	const signingRequest = didUrlState.signingRequest['signingRequest0'];
+	const serializedPayload = signingRequest.serializedPayload;
 	const serializedBytes = Buffer.from(serializedPayload, 'base64');
 	const signature = sign(privKeyBytes, serializedBytes);
 
 	const secret = {
-		signingResponse: [
-			{
-				kid: didUrlState.signingRequest[0].kid,
+		signingResponse: {
+			signingRequest0: {
+				kid: signingRequest.kid,
 				signature: toString(signature, 'base64'),
 			},
-		],
+		},
 	};
 
 	const resourceCreate = await request.post(`/1.0/createResource`, {

--- a/tests/resource/03-updateResource.spec.ts
+++ b/tests/resource/03-updateResource.spec.ts
@@ -38,7 +38,8 @@ test('resource-update. Initiate Resource update procedure', async ({ request }) 
 test('resource-update. Send the final request for Resource update', async ({ request }) => {
 	const didPayload = getDidDocument();
 	const resourceId = getResourceId();
-	const serializedPayload = didUrlState.signingRequest[0].serializedPayload;
+	const signingRequest = didUrlState.signingRequest['signingRequest0'];
+	const serializedPayload = signingRequest.serializedPayload;
 	const serializedBytes = Buffer.from(serializedPayload, 'base64');
 	const signature = sign(privKeyBytes, serializedBytes);
 
@@ -106,17 +107,18 @@ test('resource-update. Resource update without relativeDidUrl', async ({ request
 
 test('resource-update. Send the final update without relativeDidUrl', async ({ request }) => {
 	const didPayload = getDidDocument();
-	const serializedPayload = didUrlState.signingRequest[0].serializedPayload;
+	const signingRequest = didUrlState.signingRequest['signingRequest0'];
+	const serializedPayload = signingRequest.serializedPayload;
 	const serializedBytes = Buffer.from(serializedPayload, 'base64');
 	const signature = sign(privKeyBytes, serializedBytes);
 
 	const secret = {
-		signingResponse: [
-			{
-				kid: didUrlState.signingRequest[0].kid,
+		signingResponse: {
+			signingRequest0: {
+				kid: signingRequest.kid,
 				signature: toString(signature, 'base64'),
 			},
-		],
+		},
 	};
 
 	const resourceUpdate = await request.post(`/1.0/updateResource`, {

--- a/tests/resource/03-updateResource.spec.ts
+++ b/tests/resource/03-updateResource.spec.ts
@@ -44,12 +44,12 @@ test('resource-update. Send the final request for Resource update', async ({ req
 	const signature = sign(privKeyBytes, serializedBytes);
 
 	const secret = {
-		signingResponse: [
-			{
-				kid: didUrlState.signingRequest[0].kid,
+		signingResponse: {
+			signingRequest0: {
+				kid: signingRequest.kid,
 				signature: toString(signature, 'base64'),
 			},
-		],
+		},
 	};
 
 	const resourceUpdate = await request.post(`/1.0/updateResource`, {


### PR DESCRIPTION
This PR update the sigingRequest and signingResponse types from an array to object as specified in the did registration spec.