### PR TITLE
feat: Allow alsoKnownAs

### DIFF
--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -62,11 +62,17 @@ export function validateSpecCompliantPayload(didDocument: DIDDocument): SpecVali
 }
 
 function validateDidDocumentAlsoKnownAs(alsoKnownAs: unknown): boolean {
-	if (alsoKnownAs === undefined || alsoKnownAs === null) {
+	if (alsoKnownAs === undefined) {
 		return true;
 	}
+	if (alsoKnownAs === null) {
+		return false;
+	}
 
-	return Array.isArray(alsoKnownAs) && alsoKnownAs.every((item) => typeof item === 'string' && item.trim().length > 0);
+	return (
+		Array.isArray(alsoKnownAs) &&
+		alsoKnownAs.every((item) => typeof item === 'string' && item.trim().length > 0)
+	);
 }
 
 function validateServices(services: unknown): boolean {

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -54,7 +54,19 @@ export function validateSpecCompliantPayload(didDocument: DIDDocument): SpecVali
 
 	if (!isValidService) return { valid: false, error: 'Service is Invalid' };
 
+	const isValidAlsoKnownAs = validateDidDocumentAlsoKnownAs(didDocument.alsoKnownAs);
+
+	if (!isValidAlsoKnownAs) return { valid: false, error: 'alsoKnownAs is Invalid' };
+
 	return { valid: true } as SpecValidationResult;
+}
+
+function validateDidDocumentAlsoKnownAs(alsoKnownAs: unknown): boolean {
+	if (alsoKnownAs === undefined || alsoKnownAs === null) {
+		return true;
+	}
+
+	return Array.isArray(alsoKnownAs) && alsoKnownAs.every((item) => typeof item === 'string' && item.trim().length > 0);
 }
 
 function validateServices(services: unknown): boolean {

--- a/src/static/swagger.json
+++ b/src/static/swagger.json
@@ -888,6 +888,15 @@
                             "type": "string"
                         }
                     },
+                    "alsoKnownAs": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "did:web:example.com"
+                        ]
+                    },
                     "verificationMethod": {
                         "type": "array",
                         "items": {
@@ -917,6 +926,9 @@
                     ],
                     "authentication": [
                         "did:cheqd:testnet:ca9ff47c-0286-4614-a4be-8ffa83911e09#key-1"
+                    ],
+                    "alsoKnownAs": [
+                        "did:web:example.com"
                     ]
                 }
             },

--- a/tests/did/02-did-update.spec.ts
+++ b/tests/did/02-did-update.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { sign } from '@stablelib/ed25519';
+import { MsgCreateDidDocPayload } from '@cheqd/ts-proto/cheqd/did/v2/index.js';
 import { toString } from 'uint8arrays';
 import { getDidDocument, privKeyBytes } from 'fixtures';
 
@@ -155,4 +156,75 @@ test('did-update. Send the final request for updating DID with additional servic
 	expect(response.didState.didDocument.service[0].recipientKeys).toBeDefined();
 	expect(response.didState.didDocument.service[0].routingKeys).toBeDefined();
 	expect(response.didState.didDocument.service[0].accept).toBeDefined();
+});
+
+test('did-update. Initiate DID Update procedure with alsoKnownAs', async ({ request }) => {
+	didPayload = getDidDocument();
+	didPayload = {
+		...didPayload,
+		alsoKnownAs: ['did:web:example.com'],
+	};
+	const payload = await request.post('/1.0/update', {
+		data: {
+			didDocument: [didPayload],
+			did: didPayload.id,
+			secret: {},
+			options: {
+				network: 'testnet',
+			},
+		},
+	});
+
+	expect(payload.status()).toBe(200);
+
+	const body = await payload.json();
+
+	expect(body.jobId).toBeDefined();
+	expect(body.didState).toBeDefined();
+	expect(body.didState.did).toBeDefined();
+	expect(body.didState.state).toBeDefined();
+	expect(body.didState.secret).toBeDefined();
+
+	const signingRequest = body.didState.signingRequest['signingRequest0'];
+	const serializedBytes = Buffer.from(signingRequest.serializedPayload, 'base64');
+	const decodedPayload = MsgCreateDidDocPayload.decode(serializedBytes);
+	expect(decodedPayload.alsoKnownAs).toEqual(['did:web:example.com']);
+
+	didState = body.didState;
+	jobId = body.jobId;
+});
+
+test('did-update. Send the final request for updating DID with alsoKnownAs', async ({ request }) => {
+	const signingRequest = didState.signingRequest['signingRequest0'];
+	const serializedPayload = signingRequest.serializedPayload;
+	const serializedBytes = Buffer.from(serializedPayload, 'base64');
+	const signature = sign(privKeyBytes, serializedBytes);
+
+	const secret = {
+		signingResponse: {
+			signingRequest0: {
+				kid: signingRequest.kid,
+				signature: toString(signature, 'base64'),
+			},
+		},
+	};
+
+	const didUpdate = await request.post(`/1.0/update`, {
+		data: {
+			jobId: jobId,
+			secret: secret,
+			options: {
+				network: 'testnet',
+			},
+			didDocument: [didPayload],
+			did: didPayload.id,
+		},
+	});
+
+	expect(didUpdate.status()).toBe(201);
+	const response = await didUpdate.json();
+	expect(response.didState).toBeDefined();
+	expect(response.didState.state).toBe('finished');
+	expect(response.didState.didDocument).toBeDefined();
+	expect(response.didState.didDocument.alsoKnownAs).toEqual(['did:web:example.com']);
 });

--- a/tests/did/04-negative.spec.ts
+++ b/tests/did/04-negative.spec.ts
@@ -110,6 +110,9 @@ test('did-update. rejects DID Document alsoKnownAs as string', async ({ request 
 	await expectInvalidAlsoKnownAs(request, 'did:web:example.com');
 });
 
+test('did-update. rejects DID Document alsoKnownAs as null', async ({ request }) => {
+	await expectInvalidAlsoKnownAs(request, null);
+});
 test('did-update. rejects DID Document alsoKnownAs with empty string entry', async ({ request }) => {
 	await expectInvalidAlsoKnownAs(request, ['']);
 });

--- a/tests/did/04-negative.spec.ts
+++ b/tests/did/04-negative.spec.ts
@@ -1,8 +1,32 @@
-import { expect, test } from '@playwright/test';
+import { type APIRequestContext, expect, test } from '@playwright/test';
 import { getDidDocument } from 'fixtures';
 
 let indyDid = 'did:indy:sovrin:WRfXPg8dantKVubE3HX8pw';
 let deactiveDid = 'did:cheqd:testnet:ca9ff47c-0286-4614-a4be-8ffa83911e09';
+
+async function expectInvalidAlsoKnownAs(request: APIRequestContext, alsoKnownAs: unknown) {
+	const didPayload = {
+		...getDidDocument(),
+		alsoKnownAs,
+	};
+	const payload = await request.post(`/1.0/update`, {
+		data: {
+			did: didPayload.id,
+			didDocument: [didPayload],
+			options: {
+				network: 'testnet',
+			},
+		},
+	});
+
+	expect(payload.status()).toBe(400);
+
+	const body = await payload.json();
+	expect(body.didState).toBeDefined();
+	expect(body.didState.description).toEqual(
+		'Invalid payload: Provide a DID Document with at least one valid verification method'
+	);
+}
 
 test('did-create. wrong didDocument', async ({ request }) => {
 	const payload = await request.post('/1.0/create', {
@@ -80,6 +104,18 @@ test('did-update. Send wrong operation', async ({ request }) => {
 	const body = await payload.json();
 	expect(body.didState).toBeDefined();
 	expect(body.didState.description).toEqual('Invalid payload: Only Set operation is supported');
+});
+
+test('did-update. rejects DID Document alsoKnownAs as string', async ({ request }) => {
+	await expectInvalidAlsoKnownAs(request, 'did:web:example.com');
+});
+
+test('did-update. rejects DID Document alsoKnownAs with empty string entry', async ({ request }) => {
+	await expectInvalidAlsoKnownAs(request, ['']);
+});
+
+test('did-update. rejects DID Document alsoKnownAs resource-style aliases', async ({ request }) => {
+	await expectInvalidAlsoKnownAs(request, [{ uri: 'did:web:example.com', description: 'web alias' }]);
 });
 
 test('did-deactivate. invalid did', async ({ request }) => {


### PR DESCRIPTION
## Summary
- Accept DID Document `alsoKnownAs` as an optional array of non-empty strings
- Document DID Document `alsoKnownAs` in the Swagger schema and example
- Add update coverage for signed `alsoKnownAs` payloads, including protobuf decode verification
- Add negative coverage for invalid DID Document `alsoKnownAs` shapes

## Tests
- `npm run build`
- `npx playwright test -c playwright.config.ts tests/did/01-did-create.spec.ts tests/did/02-did-update.spec.ts tests/did/04-negative.spec.ts`
- `npm test`